### PR TITLE
Changed to using OpenGL ES and corrected shader usage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # SafetyCriticalOpenGL2
-This is for Practicing OpenGL SC 2.0 code.
+
+This is for Practicing OpenGL SC 2.0 code / the closest equivalent without running in certified hardware (OpenGL ES 2.0).
 
 Note that rather than focusing on MISRA C++ 2023, ontop of the C++17 standard. [HI-C++](https://en.wikipedia.org/wiki/High_Integrity_C%2B%2B) is used, this is due to it being supported by clang-tidy without having to deal with licences and subscriptions.
 
@@ -13,6 +14,9 @@ C++17 is used as the langage standard.
 - Rendering of terrain.
 - Rendering of textured quads.
 - Rendering of bitmap fonts.
+- OpenGL ES 2.0 is used to ensure similarity to OpenGL SC 2.0 covering:
+	- OpenGL ES 2.0 drawing context used at initilaisation time.
+	- All glsl shaders use `#version 100` which is the only accepted shader version supporting under OpenGL SC 2.0.
 
 ## TODOs
 
@@ -20,8 +24,6 @@ Some remaining improvement exist.
 
 ### Must Address areas
 
-- Update the OpenGL context creation to ensure [OpenGL SC 2.0](https://registry.khronos.org/OpenGL/specs/sc/sc_spec_2.0.pdf) is used.
-- Update the shaders to use `GL_SC_VERSION` when defining the GLSL version in shaders.
 - Update the clang-tidy useage to use a [compilation database](https://cmake.org/cmake/help/latest/variable/CMAKE_EXPORT_COMPILE_COMMANDS.html) and jq to iterate over the files being compiled via a .sh script.
 - Bugfix: T-Junction detection and elimination. In the vertex & index buffer population code for the terrain.
 - Custom memory allocators.

--- a/source/library/library_main.cpp
+++ b/source/library/library_main.cpp
@@ -111,9 +111,11 @@ void library_main::initialise()
 
 GLFWwindow* library_main::initialise_window()
 {
-	glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3); // todo figure out correct values of SC 2.0
-	glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3); // ''
-	glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE); // ''
+	// We request OpenGL ES 2.0, this is what OpenGL SC 2.0 is based off.
+	// This is the closest possible to what's supported by glfw.
+	glfwWindowHint(GLFW_CLIENT_API, GLFW_OPENGL_ES_API); 
+	glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 2);
+	glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 0);
 #ifdef NDEBUG
 	// non debug code.
 #else

--- a/source/library/render/renderer.cpp
+++ b/source/library/render/renderer.cpp
@@ -60,7 +60,7 @@ void renderer::render_frame()
 	glClearColor(m_clear_colour.r, m_clear_colour.g, m_clear_colour.b, m_clear_colour.a);
 	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
-	const render_mode current_render_mode = get_render_mode();
+	const render_mode current_render_mode = get_render_mode(); // this isn't supported anymore! because we're using OpenGL ES glPolygonMode() isn't supported.
 	switch (current_render_mode)
 	{
 		case render_mode::POINTS: glPolygonMode(GL_FRONT_AND_BACK, GL_POINT); break;

--- a/source/library/render/renderer.cpp
+++ b/source/library/render/renderer.cpp
@@ -187,25 +187,25 @@ void renderer::set_render_mode(render_mode render_mode)
 void renderer::initialise_shaders()
 {
 #ifdef _DEBUG
-	printf_s("Compiling static mesh vertex shader");
+	printf_s("Compiling static mesh vertex shader\n");
 	m_static_geometry_vertex_shader_object_id = shaders_compilation::compile_shader(gl::GL_VERTEX_SHADER, STATIC_MESH_VERTEX_SHADER);
-	printf_s("Compiling static mesh fragment shader");
+	printf_s("Compiling static mesh fragment shader\n");
 	m_static_geometry_fragment_shader_id = shaders_compilation::compile_shader(gl::GL_FRAGMENT_SHADER, STATIC_MESH_FRAGMENT_SHADER);
-	printf_s("linking static mesh shader");
+	printf_s("linking static mesh shader\n");
 	m_static_geometry_program_id = shaders_compilation::link_shaders_to_program(m_static_geometry_vertex_shader_object_id, m_static_geometry_fragment_shader_id);
 
-	printf_s("Compiling textured quad vertex shader");
+	printf_s("Compiling textured quad vertex shader\n");
 	m_textured_quad_geometry_vertex_shader_object_id = shaders_compilation::compile_shader(gl::GL_VERTEX_SHADER, TEXTURED_QUAD_VERTEX_SHADER);
-	printf_s("Compiling textured quad fragment shader");
+	printf_s("Compiling textured quad fragment shader\n");
 	m_textured_quad_geometry_fragment_shander_id = shaders_compilation::compile_shader(gl::GL_FRAGMENT_SHADER, TEXTURED_QUAD_FRAGMENT_SHADER);
-	printf_s("linking textured quad vertex shader");
+	printf_s("linking textured quad vertex shader\n");
 	m_textured_quad_geometry_program_id = shaders_compilation::link_shaders_to_program(m_textured_quad_geometry_vertex_shader_object_id, m_textured_quad_geometry_fragment_shander_id);
 
-	printf_s("Compiling terrain vertex shader");
+	printf_s("Compiling terrain vertex shader\n");
 	m_terrain_vertex_shader_object_id = shaders_compilation::compile_shader(gl::GL_VERTEX_SHADER, TERRAIN_VERTEX_SHADER);
-	printf_s("Compiling terrain fragment shader");
+	printf_s("Compiling terrain fragment shader\n");
 	m_terrain_fragment_shander_id = shaders_compilation::compile_shader(gl::GL_FRAGMENT_SHADER, TERRAIN_FRAGMENT_SHADER);
-	printf_s("linking terrain shader");
+	printf_s("linking terrain shader\n");
 	m_terrain_program_id = shaders_compilation::link_shaders_to_program(m_terrain_vertex_shader_object_id, m_terrain_fragment_shander_id);
 #else
 	m_static_geometry_vertex_shader_object_id = shaders_compilation::compile_shader(gl::GL_VERTEX_SHADER, STATIC_MESH_VERTEX_SHADER);

--- a/source/library/render/renderer.cpp
+++ b/source/library/render/renderer.cpp
@@ -186,6 +186,28 @@ void renderer::set_render_mode(render_mode render_mode)
 
 void renderer::initialise_shaders()
 {
+#ifdef _DEBUG
+	printf_s("Compiling static mesh vertex shader");
+	m_static_geometry_vertex_shader_object_id = shaders_compilation::compile_shader(gl::GL_VERTEX_SHADER, STATIC_MESH_VERTEX_SHADER);
+	printf_s("Compiling static mesh fragment shader");
+	m_static_geometry_fragment_shader_id = shaders_compilation::compile_shader(gl::GL_FRAGMENT_SHADER, STATIC_MESH_FRAGMENT_SHADER);
+	printf_s("linking static mesh shader");
+	m_static_geometry_program_id = shaders_compilation::link_shaders_to_program(m_static_geometry_vertex_shader_object_id, m_static_geometry_fragment_shader_id);
+
+	printf_s("Compiling textured quad vertex shader");
+	m_textured_quad_geometry_vertex_shader_object_id = shaders_compilation::compile_shader(gl::GL_VERTEX_SHADER, TEXTURED_QUAD_VERTEX_SHADER);
+	printf_s("Compiling textured quad fragment shader");
+	m_textured_quad_geometry_fragment_shander_id = shaders_compilation::compile_shader(gl::GL_FRAGMENT_SHADER, TEXTURED_QUAD_FRAGMENT_SHADER);
+	printf_s("linking textured quad vertex shader");
+	m_textured_quad_geometry_program_id = shaders_compilation::link_shaders_to_program(m_textured_quad_geometry_vertex_shader_object_id, m_textured_quad_geometry_fragment_shander_id);
+
+	printf_s("Compiling terrain vertex shader");
+	m_terrain_vertex_shader_object_id = shaders_compilation::compile_shader(gl::GL_VERTEX_SHADER, TERRAIN_VERTEX_SHADER);
+	printf_s("Compiling terrain fragment shader");
+	m_terrain_fragment_shander_id = shaders_compilation::compile_shader(gl::GL_FRAGMENT_SHADER, TERRAIN_FRAGMENT_SHADER);
+	printf_s("linking terrain shader");
+	m_terrain_program_id = shaders_compilation::link_shaders_to_program(m_terrain_vertex_shader_object_id, m_terrain_fragment_shander_id);
+#else
 	m_static_geometry_vertex_shader_object_id = shaders_compilation::compile_shader(gl::GL_VERTEX_SHADER, STATIC_MESH_VERTEX_SHADER);
 	m_static_geometry_fragment_shader_id = shaders_compilation::compile_shader(gl::GL_FRAGMENT_SHADER, STATIC_MESH_FRAGMENT_SHADER);
 	m_static_geometry_program_id = shaders_compilation::link_shaders_to_program(m_static_geometry_vertex_shader_object_id, m_static_geometry_fragment_shader_id);
@@ -197,6 +219,7 @@ void renderer::initialise_shaders()
 	m_terrain_vertex_shader_object_id = shaders_compilation::compile_shader(gl::GL_VERTEX_SHADER, TERRAIN_VERTEX_SHADER);
 	m_terrain_fragment_shander_id = shaders_compilation::compile_shader(gl::GL_FRAGMENT_SHADER, TERRAIN_FRAGMENT_SHADER);
 	m_terrain_program_id = shaders_compilation::link_shaders_to_program(m_terrain_vertex_shader_object_id, m_terrain_fragment_shander_id);
+#endif // _DEBUG
 }
 
 void renderer::shutdown_shaders()

--- a/source/library/render/renderer.cpp
+++ b/source/library/render/renderer.cpp
@@ -192,33 +192,63 @@ void renderer::initialise_shaders()
 	printf_s("Compiling static mesh fragment shader\n");
 	m_static_geometry_fragment_shader_id = shaders_compilation::compile_shader(gl::GL_FRAGMENT_SHADER, STATIC_MESH_FRAGMENT_SHADER);
 	printf_s("linking static mesh shader\n");
-	m_static_geometry_program_id = shaders_compilation::link_shaders_to_program(m_static_geometry_vertex_shader_object_id, m_static_geometry_fragment_shader_id);
+	m_static_geometry_program_id = shaders_compilation::link_shaders_to_program(m_static_geometry_vertex_shader_object_id, m_static_geometry_fragment_shader_id,
+		{
+			"vs_in_position",
+			"vs_in_uv",
+			"vs_in_normal"
+		});
 
 	printf_s("Compiling textured quad vertex shader\n");
 	m_textured_quad_geometry_vertex_shader_object_id = shaders_compilation::compile_shader(gl::GL_VERTEX_SHADER, TEXTURED_QUAD_VERTEX_SHADER);
 	printf_s("Compiling textured quad fragment shader\n");
 	m_textured_quad_geometry_fragment_shander_id = shaders_compilation::compile_shader(gl::GL_FRAGMENT_SHADER, TEXTURED_QUAD_FRAGMENT_SHADER);
 	printf_s("linking textured quad vertex shader\n");
-	m_textured_quad_geometry_program_id = shaders_compilation::link_shaders_to_program(m_textured_quad_geometry_vertex_shader_object_id, m_textured_quad_geometry_fragment_shander_id);
+	m_textured_quad_geometry_program_id = shaders_compilation::link_shaders_to_program(m_textured_quad_geometry_vertex_shader_object_id, m_textured_quad_geometry_fragment_shander_id,
+		{
+			"vs_in_position_in_pixels",
+			"vs_in_uv"
+		});
 
 	printf_s("Compiling terrain vertex shader\n");
 	m_terrain_vertex_shader_object_id = shaders_compilation::compile_shader(gl::GL_VERTEX_SHADER, TERRAIN_VERTEX_SHADER);
 	printf_s("Compiling terrain fragment shader\n");
 	m_terrain_fragment_shander_id = shaders_compilation::compile_shader(gl::GL_FRAGMENT_SHADER, TERRAIN_FRAGMENT_SHADER);
 	printf_s("linking terrain shader\n");
-	m_terrain_program_id = shaders_compilation::link_shaders_to_program(m_terrain_vertex_shader_object_id, m_terrain_fragment_shander_id);
+	m_terrain_program_id = shaders_compilation::link_shaders_to_program(m_terrain_vertex_shader_object_id, m_terrain_fragment_shander_id,
+		{
+			"vs_in_position",
+			"vs_in_uv",
+			"vs_in_normal",
+			"vs_in_terrain_uv"
+		});
 #else
 	m_static_geometry_vertex_shader_object_id = shaders_compilation::compile_shader(gl::GL_VERTEX_SHADER, STATIC_MESH_VERTEX_SHADER);
 	m_static_geometry_fragment_shader_id = shaders_compilation::compile_shader(gl::GL_FRAGMENT_SHADER, STATIC_MESH_FRAGMENT_SHADER);
-	m_static_geometry_program_id = shaders_compilation::link_shaders_to_program(m_static_geometry_vertex_shader_object_id, m_static_geometry_fragment_shader_id);
+	m_static_geometry_program_id = shaders_compilation::link_shaders_to_program(m_static_geometry_vertex_shader_object_id, m_static_geometry_fragment_shader_id,
+		{
+			"vs_in_position",
+			"vs_in_uv",
+			"vs_in_normal"
+		});
 
 	m_textured_quad_geometry_vertex_shader_object_id = shaders_compilation::compile_shader(gl::GL_VERTEX_SHADER, TEXTURED_QUAD_VERTEX_SHADER);
 	m_textured_quad_geometry_fragment_shander_id = shaders_compilation::compile_shader(gl::GL_FRAGMENT_SHADER, TEXTURED_QUAD_FRAGMENT_SHADER);
-	m_textured_quad_geometry_program_id = shaders_compilation::link_shaders_to_program(m_textured_quad_geometry_vertex_shader_object_id, m_textured_quad_geometry_fragment_shander_id);
+	m_textured_quad_geometry_program_id = shaders_compilation::link_shaders_to_program(m_textured_quad_geometry_vertex_shader_object_id, m_textured_quad_geometry_fragment_shander_id,
+		{
+			"vs_in_position_in_pixels",
+			"vs_in_uv"
+		});
 
 	m_terrain_vertex_shader_object_id = shaders_compilation::compile_shader(gl::GL_VERTEX_SHADER, TERRAIN_VERTEX_SHADER);
 	m_terrain_fragment_shander_id = shaders_compilation::compile_shader(gl::GL_FRAGMENT_SHADER, TERRAIN_FRAGMENT_SHADER);
-	m_terrain_program_id = shaders_compilation::link_shaders_to_program(m_terrain_vertex_shader_object_id, m_terrain_fragment_shander_id);
+	m_terrain_program_id = shaders_compilation::link_shaders_to_program(m_terrain_vertex_shader_object_id, m_terrain_fragment_shander_id,
+		{
+			"vs_in_position",
+			"vs_in_uv",
+			"vs_in_normal",
+			"vs_in_terrain_uv"
+		});
 #endif // _DEBUG
 }
 

--- a/source/library/render/shaders/shaders_compilation.cpp
+++ b/source/library/render/shaders/shaders_compilation.cpp
@@ -3,6 +3,7 @@
 #include "../include_opengl.h"
 
 #include <iostream>
+#include <vector>
 
 gl::GLuint shaders_compilation::compile_shader(gl::GLenum type, const char* src)
 {
@@ -22,21 +23,25 @@ gl::GLuint shaders_compilation::compile_shader(gl::GLenum type, const char* src)
 	return s;
 }
 
-gl::GLuint shaders_compilation::link_shaders_to_program(gl::GLuint vertex_shader_id, gl::GLuint fragment_shader_id)
+gl::GLuint shaders_compilation::link_shaders_to_program(gl::GLuint vertex_shader_id, gl::GLuint fragment_shader_id, const std::vector<std::string_view>& vertex_attributes)
 {
-	gl::GLuint p = gl::glCreateProgram();
-	gl::glAttachShader(p, vertex_shader_id);
-	gl::glAttachShader(p, fragment_shader_id);
-	gl::glLinkProgram(p);
+	gl::GLuint shader_program = gl::glCreateProgram();
+	for (size_t i = 0; i < vertex_attributes.size(); ++i)
+	{
+		gl::glBindAttribLocation(shader_program, static_cast<gl::GLuint>(i), vertex_attributes[i].data());
+	}
+	gl::glAttachShader(shader_program, vertex_shader_id);
+	gl::glAttachShader(shader_program, fragment_shader_id);
+	gl::glLinkProgram(shader_program);
 	gl::GLint ok = 0;
-	gl::glGetProgramiv(p, gl::GL_LINK_STATUS, &ok);
+	gl::glGetProgramiv(shader_program, gl::GL_LINK_STATUS, &ok);
 	if (!ok)
 	{
 		char log[512];
 		std::memset(log, 0, 512);
-		gl::glGetProgramInfoLog(p, 512, nullptr, log);
+		gl::glGetProgramInfoLog(shader_program, 512, nullptr, log);
 		std::cerr << "Program link error:\n" << log << std::endl;
 		std::exit(EXIT_FAILURE);
 	}
-	return p;
+	return shader_program;
 }

--- a/source/library/render/shaders/shaders_compilation.h
+++ b/source/library/render/shaders/shaders_compilation.h
@@ -2,11 +2,13 @@
 #define _SHADER_COMPILATION_H_
 
 #include <glbinding/gl/types.h>
+#include <vector>
+#include <string_view>
 
 namespace shaders_compilation
 {
 	gl::GLuint compile_shader(gl::GLenum type, const char* src);
-	gl::GLuint link_shaders_to_program(gl::GLuint vertex_shader_id, gl::GLuint fragment_shader_id);
+	gl::GLuint link_shaders_to_program(gl::GLuint vertex_shader_id, gl::GLuint fragment_shader_id, const std::vector<std::string_view>& vertex_attributes);
 }
 
 #endif // _SHADER_COMPILATION_H_

--- a/source/library/render/shaders/static_mesh_shader.h
+++ b/source/library/render/shaders/static_mesh_shader.h
@@ -1,52 +1,51 @@
 #ifndef _STATIC_MESH_SHADER_H_
 #define _STATIC_MESH_SHADER_H_
 
-static constexpr char* STATIC_MESH_VERTEX_SHADER = R"(
-#version 330 core
+// note we're only able to use #version 100 since the code needs to be glsl ES compilent.
+static constexpr char* STATIC_MESH_VERTEX_SHADER = R"(#version 100
 
 uniform mat4 u_model;
 uniform mat4 u_view;
 uniform mat4 u_projection;
 
-layout(location = 0) in vec3 vs_in_position;
-layout(location = 1) in vec2 vs_in_uv;
-layout(location = 2) in vec3 vs_in_normal;
+attribute vec3 vs_in_position;
+attribute vec2 vs_in_uv;
+attribute vec3 vs_in_normal;
 
-out vec3 vs_out_world_position;
-out vec2 vs_out_uv;
-out vec3 vs_out_normal;
+varying vec3 vs_out_world_position;
+varying vec2 vs_out_uv;
+varying vec3 vs_out_normal;
 
 void main()
 {
     vec4 world_position = u_model * vec4(vs_in_position, 1.0);
     vs_out_world_position = world_position.xyz;
-    vs_out_normal = mat3(transpose(inverse(u_model))) * vs_in_normal;
+    vs_out_normal = mat3(u_model) * vs_in_normal;
     vs_out_uv = vs_in_uv;
 
     gl_Position = u_projection * u_view * world_position;
 }
 )";
 
-static constexpr char* STATIC_MESH_FRAGMENT_SHADER = R"(
-#version 330 core
+static constexpr char* STATIC_MESH_FRAGMENT_SHADER = R"(#version 100
 
-in vec3 vs_out_world_position;
-in vec2 vs_out_uv;
-in vec3 vs_out_normal;
+precision mediump float;
+
+varying vec3 vs_out_world_position;
+varying vec2 vs_out_uv;
+varying vec3 vs_out_normal;
 
 uniform sampler2D u_diffuse_map;
-uniform vec3      u_light_direction;     // unit vectors only
+uniform vec3      u_light_direction;
 uniform vec3      u_light_colour;
-uniform vec3      u_ambient_light_colour; // light colour
-uniform vec4      u_surface_tint;        // colour multiplier
-
-out vec4 fs_out_frag_color;
+uniform vec3      u_ambient_light_colour;
+uniform vec4      u_surface_tint;
 
 void main()
 {
-    vec4 diffuse_surface_colour = texture(u_diffuse_map, vs_out_uv);
+    vec4 diffuse_surface_colour = texture2D(u_diffuse_map, vs_out_uv);
 
-    vec3 frag_normal = normalize(vs_out_normal); // remember values from the VS are interploated.
+    vec3 frag_normal = normalize(vs_out_normal);
     vec3 to_light = normalize(-u_light_direction);
     float normal_dot_to_light = max(dot(frag_normal, to_light), 0.0);
 
@@ -54,9 +53,13 @@ void main()
     vec3 diffuse_light_colour = u_light_colour * normal_dot_to_light;
 
     vec3 combined_light_colour = ambient_light_colour + diffuse_light_colour;
-    vec4 surface_colour = vec4(diffuse_surface_colour.rgb * combined_light_colour, diffuse_surface_colour.a)
-                        * u_surface_tint;
-    fs_out_frag_color = surface_colour;
+
+    vec4 surface_colour = vec4(
+        diffuse_surface_colour.rgb * combined_light_colour,
+        diffuse_surface_colour.a
+    ) * u_surface_tint;
+
+    gl_FragColor = surface_colour;
 }
 )";
 

--- a/source/library/render/shaders/terrain_shader.h
+++ b/source/library/render/shaders/terrain_shader.h
@@ -1,28 +1,31 @@
 #ifndef _TERRAIN_SHADER_H_
 #define _TERRAIN_SHADER_H_
 
-static constexpr char* TERRAIN_VERTEX_SHADER = R"(
-#version 330 core
+// note we're only able to use #version 100 since the code needs to be glsl ES compilent.
+static constexpr char* TERRAIN_VERTEX_SHADER = R"(#version 100
 
 uniform mat4 u_model;
 uniform mat4 u_view;
 uniform mat4 u_projection;
 
-layout(location = 0) in vec3 vs_in_position;
-layout(location = 1) in vec2 vs_in_uv;
-layout(location = 2) in vec3 vs_in_normal;
-layout(location = 3) in vec2 vs_in_terrain_uv;
+attribute vec3 vs_in_position;
+attribute vec2 vs_in_uv;
+attribute vec3 vs_in_normal;
+attribute vec2 vs_in_terrain_uv;
 
-out vec3 vs_out_world_position;
-out vec2 vs_out_uv;
-out vec3 vs_out_normal;
-out vec2 vs_out_terrain_uv;
+varying vec3 vs_out_world_position;
+varying vec2 vs_out_uv;
+varying vec3 vs_out_normal;
+varying vec2 vs_out_terrain_uv;
 
 void main()
 {
     vec4 world_position = u_model * vec4(vs_in_position, 1.0);
     vs_out_world_position = world_position.xyz;
-    vs_out_normal = mat3(transpose(inverse(u_model))) * vs_in_normal;
+
+    // No scaling assumption
+    vs_out_normal = mat3(u_model) * vs_in_normal;
+
     vs_out_uv = vs_in_uv;
     vs_out_terrain_uv = vs_in_terrain_uv;
 
@@ -30,47 +33,50 @@ void main()
 }
 )";
 
-static constexpr char* TERRAIN_FRAGMENT_SHADER = R"(
-#version 330 core
+static constexpr char* TERRAIN_FRAGMENT_SHADER = R"(#version 100
+
+precision mediump float;
 
 uniform sampler2D u_splat_map;
 uniform sampler2D u_red_channel_diffuse_map;
 uniform sampler2D u_green_channel_diffuse_map;
 uniform sampler2D u_blue_channel_diffuse_map;
 uniform sampler2D u_alpha_channel_diffuse_map;
-uniform vec3      u_light_direction;     // unit vectors only
-uniform vec3      u_light_colour;
-uniform vec3      u_ambient_light_colour; // light colour
-uniform vec4      u_terrain_blend_colour;
 
-in vec3 vs_out_world_position;
-in vec2 vs_out_uv;
-in vec3 vs_out_normal;
-in vec2 vs_out_terrain_uv;
+uniform vec3 u_light_direction;
+uniform vec3 u_light_colour;
+uniform vec3 u_ambient_light_colour;
+uniform vec4 u_terrain_blend_colour;
 
-out vec4 fs_out_frag_color;
+varying vec3 vs_out_world_position;
+varying vec2 vs_out_uv;
+varying vec3 vs_out_normal;
+varying vec2 vs_out_terrain_uv;
 
 void main()
 {
-    vec4 weights = texture(u_splat_map, vs_out_uv);
+    vec4 weights = texture2D(u_splat_map, vs_out_uv);
 
-    vec3 frag_normal = normalize(vs_out_normal); // remember values from the VS are interploated.
+    vec3 frag_normal = normalize(vs_out_normal);
     vec3 to_light = normalize(-u_light_direction);
     float normal_dot_to_light = max(dot(frag_normal, to_light), 0.0);
 
     vec3 ambient_light_colour = u_ambient_light_colour;
     vec3 diffuse_light_colour = u_light_colour * normal_dot_to_light;
-
     vec3 combined_light_colour = ambient_light_colour + diffuse_light_colour;
 
     vec4 combined_diffuse_colour =
-      texture(u_red_channel_diffuse_map, vs_out_terrain_uv) * weights.r +
-      texture(u_green_channel_diffuse_map, vs_out_terrain_uv) * weights.g +
-      texture(u_blue_channel_diffuse_map, vs_out_terrain_uv) * weights.b +
-      texture(u_alpha_channel_diffuse_map, vs_out_terrain_uv) * weights.a;
+        texture2D(u_red_channel_diffuse_map, vs_out_terrain_uv) * weights.r +
+        texture2D(u_green_channel_diffuse_map, vs_out_terrain_uv) * weights.g +
+        texture2D(u_blue_channel_diffuse_map, vs_out_terrain_uv) * weights.b +
+        texture2D(u_alpha_channel_diffuse_map, vs_out_terrain_uv) * weights.a;
 
-    vec4 surface_colour = vec4(combined_diffuse_colour.rgb * combined_light_colour, combined_diffuse_colour.a);
-    fs_out_frag_color = surface_colour * u_terrain_blend_colour;
+    vec4 surface_colour = vec4(
+        combined_diffuse_colour.rgb * combined_light_colour,
+        combined_diffuse_colour.a
+    );
+
+    gl_FragColor = surface_colour * u_terrain_blend_colour;
 }
 )";
 

--- a/source/library/render/shaders/textured_quad_shader.h
+++ b/source/library/render/shaders/textured_quad_shader.h
@@ -1,44 +1,45 @@
 #ifndef _TEXTURED_QUAD_SHADER_H_
 #define _TEXTURED_QUAD_SHADER_H_
 
-static constexpr char* TEXTURED_QUAD_VERTEX_SHADER = R"(
-#version 330 core
+static constexpr char* TEXTURED_QUAD_VERTEX_SHADER = R"(#version 100
 
-layout(location = 0) in vec2 vs_in_position_in_pixels;    // pixel coordinates (x, y)
-layout(location = 1) in vec2 vs_in_uv;
+attribute vec2 vs_in_position_in_pixels;
+attribute vec2 vs_in_uv;
 
-uniform vec2 u_resolution; // viewport size in pixels (width, height)
-uniform mat4 u_transform;  // optional 2D transform in pixel-space (affine). done as 4x4 to work with the class structure used.
+uniform vec2 u_resolution;
+uniform mat4 u_transform;
 
-out vec2 vs_out_uv;
+varying vec2 vs_out_uv;
 
 void main()
 {
     vec4 post_transform_px = u_transform * vec4(vs_in_position_in_pixels, 1.0, 1.0);
-    vec2 normalised_device_coords = (post_transform_px.xy / u_resolution) * 2.0 - 1.0; // [0..res] -> [-1..1]
-    normalised_device_coords.y = -normalised_device_coords.y; // flip Y (positive Y goes down)
+    vec2 normalised_device_coords = (post_transform_px.xy / u_resolution) * 2.0 - 1.0;
+    normalised_device_coords.y = -normalised_device_coords.y;
 
     gl_Position = vec4(normalised_device_coords, 0.0, 1.0);
     vs_out_uv = vs_in_uv;
 }
 )";
 
-static constexpr char* TEXTURED_QUAD_FRAGMENT_SHADER = R"(
-#version 330 core
+static constexpr char* TEXTURED_QUAD_FRAGMENT_SHADER = R"(#version 100
 
-in vec2 vs_out_uv;
+precision mediump float;
+
+varying vec2 vs_out_uv;
 
 uniform sampler2D u_texture;
-uniform vec4 u_tint;           // RGBA tint multiplier (use vec4(1.0) for no tint)
-uniform float u_alpha_cut_off; // 0.0 = disabled. otherwise alpha values below are culled
-
-out vec4 fs_out_frag_color;
+uniform vec4 u_tint;
+uniform float u_alpha_cut_off;
 
 void main()
 {
-    vec4 tex = texture(u_texture, vs_out_uv);
-    if (u_alpha_cut_off > 0.0 && tex.a <= u_alpha_cut_off) discard;
-    fs_out_frag_color = tex * u_tint;
+    vec4 tex = texture2D(u_texture, vs_out_uv);
+
+    if (u_alpha_cut_off > 0.0 && tex.a <= u_alpha_cut_off)
+        discard;
+
+    gl_FragColor = tex * u_tint;
 }
 )";
 


### PR DESCRIPTION
The application now uses OpenGL ES 2.0 instead of OpenGL 3.3, this is to more closely emulate running on OpenGL SC 2.0.

All shaders and initialisation code have been "updated" to use the changed standard.

Note that since OpenGL ES is used, glPolygonMode() no longer works, preventing from switching to wireframe and points rendering at runtime which would be useful during diagnosing terrain bugs.