### PR TITLE
Custom allocation added.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,13 @@ C++17 is used as the langage standard.
 	- All glsl shaders use `#version 100` which is the only accepted shader version supporting under OpenGL SC 2.0.
 - Clang-tidy is used with a [compilation database](https://cmake.org/cmake/help/latest/variable/CMAKE_EXPORT_COMPILE_COMMANDS.html) and jq to iterate over the files being compiled via a .sh script.
 	- Dependencies are excluded from the checks.
+- Custom memory allocators.
+    - Initialisation phase, no limit, but won't allow allocations once initialisation finishes.
+	- Running phase, fixed size, can allow allocations after Initialisation.
 
 ## TODOs
 
 Some remaining improvements exist.
-
-- Custom memory allocators.
-    - Initialisation phase, no limit, but won't allow allocations once initialisation finishes.
-	- Running phase, fixed size, can allow allocations after Initialisation.
 
 ### Must Address areas
 

--- a/README.md
+++ b/README.md
@@ -24,12 +24,13 @@ C++17 is used as the langage standard.
 
 Some remaining improvements exist.
 
-### Must Address areas
-
-- Bugfix: T-Junction detection and elimination. In the vertex & index buffer population code for the terrain.
 - Custom memory allocators.
     - Initialisation phase, no limit, but won't allow allocations once initialisation finishes.
 	- Running phase, fixed size, can allow allocations after Initialisation.
+
+### Must Address areas
+
+- Bugfix: T-Junction detection and elimination. In the vertex & index buffer population code for the terrain.
 - (Once all of the above are addressed) Update the code to be HI C++ complient.
 
 ### Should Address areas (on revisiting the project)

--- a/source/library/library_main.cpp
+++ b/source/library/library_main.cpp
@@ -5,6 +5,7 @@
 #include "render/3d/camera.h"
 #include "render/include_opengl.h"
 #include "render/renderer.h"
+#include "memory/memory_system.h"
 #include "utilities/text_utilities.h"
 
 #include <filesystem>
@@ -41,7 +42,9 @@ library_main::~library_main()
 
 void library_main::run()
 {
+	memory::set_phase(memory::phase::initialisation);
 	initialise();
+	memory::set_phase(memory::phase::runtime);
 	static float running_time = 0.0f;
 	while (!glfwWindowShouldClose(m_window))
 	{
@@ -52,6 +55,7 @@ void library_main::run()
 		glfwSwapBuffers(m_window);
 		glfwPollEvents();
 	}
+	memory::set_phase(memory::phase::shutdown);
 	shutdown();
 }
 

--- a/source/library/library_main.cpp
+++ b/source/library/library_main.cpp
@@ -296,19 +296,6 @@ void library_main::tick(float delta_time)
 	text_to_set = U"Camera movement speed: ";
 	text_utilities::append_vec3(text_to_set, { m_camera->get_move_speed(), 0.0f, 0.0f });
 	m_camera_move_speed_text->set_text(text_to_set);
-
-	if (glfwGetKey(m_window, GLFW_KEY_1) == GLFW_PRESS)
-	{
-		m_renderer->set_render_mode(render_mode::FILL);
-	}
-	else if (glfwGetKey(m_window, GLFW_KEY_2) == GLFW_PRESS) 
-	{
-		m_renderer->set_render_mode(render_mode::LINES);
-	}
-	else if (glfwGetKey(m_window, GLFW_KEY_3) == GLFW_PRESS) 
-	{
-		m_renderer->set_render_mode(render_mode::POINTS);
-	}
 }
 
 void library_main::update_text_tints()

--- a/source/library/library_main.cpp
+++ b/source/library/library_main.cpp
@@ -6,6 +6,7 @@
 #include "render/include_opengl.h"
 #include "render/renderer.h"
 #include "memory/memory_system.h"
+#include "memory/runtime_phase_allocator.h"
 #include "utilities/text_utilities.h"
 
 #include <filesystem>
@@ -42,9 +43,10 @@ library_main::~library_main()
 
 void library_main::run()
 {
-	memory::set_phase(memory::phase::initialisation);
+	memory_system::set_phase(memory_system::phase::initialisation);
 	initialise();
-	memory::set_phase(memory::phase::runtime);
+	runtime_allocator::initialise();
+	memory_system::set_phase(memory_system::phase::runtime);
 	static float running_time = 0.0f;
 	while (!glfwWindowShouldClose(m_window))
 	{
@@ -55,7 +57,7 @@ void library_main::run()
 		glfwSwapBuffers(m_window);
 		glfwPollEvents();
 	}
-	memory::set_phase(memory::phase::shutdown);
+	memory_system::set_phase(memory_system::phase::shutdown);
 	shutdown();
 }
 

--- a/source/library/memory/initialisation_phase_allocator.cpp
+++ b/source/library/memory/initialisation_phase_allocator.cpp
@@ -1,0 +1,24 @@
+#include "initialisation_phase_allocator.h"
+
+#include "memory_system.h"
+
+#include <memory>
+
+void* initialisation_allocator::allocate(size_t size)
+{
+	if (memory_system::get_phase() == memory_system::phase::runtime)
+	{
+		memory_system::allocation_violation("Initialisation allocator used at runtime.");
+	}
+	void* pointer = std::malloc(size);
+	if (pointer == nullptr)
+	{
+		throw std::bad_alloc{};
+	}
+	return pointer;
+}
+
+void initialisation_allocator::deallocate(void* pointer) noexcept
+{
+	std::free(pointer);
+}

--- a/source/library/memory/initialisation_phase_allocator.h
+++ b/source/library/memory/initialisation_phase_allocator.h
@@ -1,0 +1,14 @@
+#ifndef _INITIALISATION_PHASE_ALLOCATOR_H_
+#define _INITIALISATION_PHASE_ALLOCATOR_H_
+
+
+
+class initialisation_allocator
+{
+public:
+
+	static void* allocate(size_t size);
+	static void deallocate(void* pointer) noexcept;
+};
+
+#endif // _INITIALISATION_PHASE_ALLOCATOR_H_

--- a/source/library/memory/memory_system.cpp
+++ b/source/library/memory/memory_system.cpp
@@ -1,0 +1,29 @@
+#include "memory_system.h"
+
+#include <iostream>
+
+namespace memory
+{
+	static phase current_phase = phase::initialisation;
+
+
+	void set_phase(phase phase)
+	{
+		current_phase = phase;
+	}
+
+	phase get_phase()
+	{
+		return current_phase;
+	}
+
+	[[noreturn]]
+	void allocation_violation(const char* reason)
+	{
+		std::cerr << "MEMORY ALLOCATION VIOLATION: "
+			<< reason
+			<< std::endl;
+
+		std::abort();
+	}
+}

--- a/source/library/memory/memory_system.cpp
+++ b/source/library/memory/memory_system.cpp
@@ -2,7 +2,7 @@
 
 #include <iostream>
 
-namespace memory
+namespace memory_system
 {
 	static phase current_phase = phase::initialisation;
 

--- a/source/library/memory/memory_system.h
+++ b/source/library/memory/memory_system.h
@@ -3,7 +3,7 @@
 
 #include <cstdint>
 
-namespace memory
+namespace memory_system
 {
 	enum class phase : std::uint8_t
 	{

--- a/source/library/memory/memory_system.h
+++ b/source/library/memory/memory_system.h
@@ -1,0 +1,22 @@
+#ifndef _MEMORY_SYSTEM_H_
+#define _MEMORY_SYSTEM_H_
+
+#include <cstdint>
+
+namespace memory
+{
+	enum class phase : std::uint8_t
+	{
+		initialisation,
+		runtime,
+		shutdown
+	};
+
+	void set_phase(phase phase);
+	phase get_phase();
+
+	[[noreturn]]
+	void allocation_violation(const char* reason);
+}
+
+#endif // _MEMORY_SYSTEM_H_

--- a/source/library/memory/new_delete_overrides.cpp
+++ b/source/library/memory/new_delete_overrides.cpp
@@ -1,0 +1,44 @@
+#include "memory_system.h"
+
+#include "initialisation_phase_allocator.h"
+#include "runtime_phase_allocator.h"
+
+#include <cstdint>
+#include <memory>
+
+void* operator new(size_t size)
+{
+	if (memory_system::get_phase() == memory_system::phase::runtime)
+	{
+		return runtime_allocator::allocate(size);
+	}
+	return initialisation_allocator::allocate(size);
+}
+
+void operator delete(void* pointer) noexcept
+{
+	if (memory_system::get_phase() == memory_system::phase::runtime)
+	{
+		return runtime_allocator::deallocate(pointer);
+	}
+	return initialisation_allocator::deallocate(pointer);
+}
+
+void* operator new[](std::size_t size)
+{
+	if (memory_system::get_phase() == memory_system::phase::runtime)
+	{
+		return runtime_allocator::allocate(size);
+	}
+	return initialisation_allocator::allocate(size);
+}
+
+void operator delete[](void* pointer) noexcept
+{
+	if (memory_system::get_phase() == memory_system::phase::runtime)
+	{
+		return runtime_allocator::deallocate(pointer);
+	}
+	return initialisation_allocator::deallocate(pointer);
+}
+

--- a/source/library/memory/runtime_phase_allocator.cpp
+++ b/source/library/memory/runtime_phase_allocator.cpp
@@ -1,0 +1,105 @@
+#include "runtime_phase_allocator.h"
+
+#include "memory_system.h"
+
+void runtime_allocator::initialise()
+{
+	free_list =
+		reinterpret_cast<block_header*>(pool.data());
+
+	free_list->size =
+		pool_size - sizeof(block_header);
+
+	free_list->free = true;
+	free_list->next = nullptr;
+
+	initialised = true;
+}
+
+void* runtime_allocator::allocate(size_t size)
+{
+	if (!initialised)
+	{
+		memory_system::allocation_violation(
+			"runtime allocator not initialised");
+	}
+
+	std::lock_guard<std::mutex> guard(lock);
+
+	block_header* current = free_list;
+
+	while (current)
+	{
+		if (current->free &&
+			current->size >= size)
+		{
+			const std::size_t remaining =
+				current->size - size;
+
+			if (remaining >
+				sizeof(block_header))
+			{
+				auto* next =
+					reinterpret_cast<block_header*>(
+						reinterpret_cast<std::uint8_t*>(
+							current + 1) + size);
+
+				next->size =
+					remaining - sizeof(block_header);
+
+				next->free = true;
+				next->next = current->next;
+
+				current->next = next;
+				current->size = size;
+			}
+
+			current->free = false;
+
+			return current + 1;
+		}
+
+		current = current->next;
+	}
+
+	memory_system::allocation_violation(
+		"runtime allocator exhausted");
+
+	return nullptr;
+}
+
+void runtime_allocator::deallocate(void* ptr) noexcept
+{
+	if (!ptr)
+	{
+		return;
+	}
+
+	std::lock_guard<std::mutex> guard(lock);
+
+	auto* header =
+		reinterpret_cast<block_header*>(ptr) - 1;
+
+	header->free = true;
+
+	// Basic coalescing
+	block_header* current = free_list;
+
+	while (current && current->next)
+	{
+		if (current->free &&
+			current->next->free)
+		{
+			current->size +=
+				sizeof(block_header) +
+				current->next->size;
+
+			current->next =
+				current->next->next;
+		}
+		else
+		{
+			current = current->next;
+		}
+	}
+}

--- a/source/library/memory/runtime_phase_allocator.h
+++ b/source/library/memory/runtime_phase_allocator.h
@@ -1,0 +1,33 @@
+#ifndef _RUNTIME_PHASE_ALLOCATOR_H_
+#define _RUNTIME_PHASE_ALLOCATOR_H_
+
+#include <mutex>
+#include <array>
+
+// this class is LLM generated.
+
+class runtime_allocator
+{
+public:
+	static constexpr size_t pool_size = 1024 * 1024; // 1MB.
+
+	static void initialise();
+
+	static void* allocate(size_t size);
+	static void deallocate(void* ptr) noexcept;
+
+private:
+	struct block_header
+	{
+		size_t size;
+		bool free;
+		block_header* next;
+	};
+
+	inline static std::array<std::uint8_t, pool_size> pool{};
+	inline static block_header* free_list = nullptr;
+	inline static bool initialised = false;
+	inline static std::mutex lock;
+};
+
+#endif // _RUNTIME_PHASE_ALLOCATOR_H_

--- a/source/library/render/renderer.cpp
+++ b/source/library/render/renderer.cpp
@@ -60,20 +60,12 @@ void renderer::render_frame()
 	glClearColor(m_clear_colour.r, m_clear_colour.g, m_clear_colour.b, m_clear_colour.a);
 	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
-	const render_mode current_render_mode = get_render_mode(); // this isn't supported anymore! because we're using OpenGL ES glPolygonMode() isn't supported.
-	switch (current_render_mode)
-	{
-		case render_mode::POINTS: glPolygonMode(GL_FRONT_AND_BACK, GL_POINT); break;
-		case render_mode::LINES: glPolygonMode(GL_FRONT_AND_BACK, GL_LINE); break;
-		case render_mode::FILL: glPolygonMode(GL_FRONT_AND_BACK, GL_FILL); break;
-		default: break;
-	}
-
 	for (auto to_draw_iter : m_render_list)
 	{
 		auto to_draw = to_draw_iter.lock();
 		switch (to_draw->get_renderable_type())
 		{
+			// TODO (on revisting the project, skybox rendering):
 			case renderable_type::TERRAIN: switch_to_terrain_shader(); break;
 			case renderable_type::STATIC_GEOMETRY: switch_to_3d_static_mesh_shader(); break;
 			case renderable_type::_2D_GEOMETRY: switch_to_2d_shader(); break;
@@ -151,11 +143,6 @@ glm::vec3 renderer::get_directional_light_direction() const
 	return m_directional_light_direction;
 }
 
-render_mode renderer::get_render_mode() const
-{
-	return m_render_mode;
-}
-
 void renderer::set_clear_colour(glm::vec4 colour)
 {
 	m_clear_colour = colour;
@@ -174,11 +161,6 @@ void renderer::set_directional_light_colour(glm::vec3 colour)
 void renderer::set_directional_light_direction(glm::vec3 direction)
 {
 	m_directional_light_direction = direction;
-}
-
-void renderer::set_render_mode(render_mode render_mode)
-{
-	m_render_mode = render_mode;
 }
 
 // private

--- a/source/library/render/renderer.h
+++ b/source/library/render/renderer.h
@@ -42,13 +42,11 @@ public:
 	glm::vec3 get_ambient_light_colour() const;
 	glm::vec3 get_directional_light_colour() const;
 	glm::vec3 get_directional_light_direction() const;
-	render_mode get_render_mode() const;
 
 	void set_clear_colour(glm::vec4 colour);
 	void set_ambient_light_colour(glm::vec3 colour);
 	void set_directional_light_colour(glm::vec3 colour);
 	void set_directional_light_direction(glm::vec3 direction);
-	void set_render_mode(render_mode render_mode);
 
 private:
 
@@ -82,8 +80,6 @@ private:
 	std::vector<std::weak_ptr<renderable>> m_render_list;
 	std::weak_ptr<const camera> m_camera;
 	const size_t m_render_list_cap { 0 };
-
-	render_mode m_render_mode = render_mode::FILL;
 };
 
 #endif // _RENDERER_H_


### PR DESCRIPTION
The ensure correct allocator usage new and delete are overridden.

Two allocators are added:
1. Initialisation phase, no cap on usage, but will not allocate once the runtime phase is reached. Deallocation is allowed during shutdown.
2. Runtime phase, 1MB cap, allows allocation and deallocation during runtime.
